### PR TITLE
[figma]:update to 0.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zhb-vue-icon",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Juuust Vue Icon, Automation workflow with Figma",
   "main": "bundle/index.common.js",
   "files": [


### PR DESCRIPTION
重命名图层名字，不能有(）/括号斜线