### PR TITLE
[figma]:update to 2.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zhb-vue-icon",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "ZHB Vue Icon, Automation workflow with Figma",
   "main": "bundle/index.common.js",
   "files": [


### PR DESCRIPTION
修复命名不支持字符